### PR TITLE
Fix compilation for the latest nightly

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -52,7 +52,7 @@ impl Client {
     }
 
     pub fn get_prepared_statement(&mut self, ps_id: &str) -> RCResult<&CqlPreparedStat> {
-        match self.prepared.get(&String::from_str(ps_id)) {
+        match self.prepared.get(ps_id) {
             Some(ps) => Ok(&**ps),
             None => return Err(RCError::new(format!("Unknown prepared statement <{}>", ps_id), GenericError))
         }
@@ -142,7 +142,7 @@ impl Client {
         let res = try_rc!(socket.read_cql_response(self.version), "Error reading query");
         match res.body {
             ResultPrepared(preps) => {
-                self.prepared.insert(String::from_str(query_id), preps);
+                self.prepared.insert(query_id.to_string(), preps);
                 Ok(())
             },
             _ => Err(RCError::new("Response does not contain prepared statement", ReadError))

--- a/src/def.rs
+++ b/src/def.rs
@@ -12,7 +12,7 @@ use std::ops::Deref;
 pub type SendStr = Cow<'static, str>;
 
 
-#[derive(ToPrimitive, Copy)]
+#[derive(ToPrimitive, Clone, Copy)]
 pub enum OpcodeRequest {
     //requests
     OpcodeStartup = 0x01,
@@ -72,7 +72,7 @@ pub fn opcode_response(val: u8) -> OpcodeResponse {
 }
 
 
-#[derive(ToPrimitive, Copy)]
+#[derive(ToPrimitive, Clone, Copy)]
 pub enum Consistency {
     Any = 0x0000,
     One = 0x0001,
@@ -85,7 +85,7 @@ pub enum Consistency {
     Unknown,
 }
 
-#[derive(ToPrimitive, Copy)]
+#[derive(ToPrimitive, Clone, Copy)]
 pub enum BatchType {
     Logged = 0x00,
     Unlogged = 0x01,
@@ -213,7 +213,7 @@ pub struct CqlPair {
     pub value: &'static str,
 }
 
-#[derive(Debug, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum CqlBytesSize {
    Cqli32,
    Cqli16 

--- a/src/def.rs
+++ b/src/def.rs
@@ -190,8 +190,8 @@ impl std::fmt::Display for RCError {
     }
 }
 
-impl std::error::FromError<std::io::Error> for RCError {
-    fn from_error(err: std::io::Error) -> RCError {
+impl std::convert::From<std::io::Error> for RCError {
+    fn from(err: std::io::Error) -> RCError {
         RCError { kind: RCErrorType::IOError, desc: String::from_str(err.description()).into_cow() }   
     }
 }

--- a/src/def.rs
+++ b/src/def.rs
@@ -8,6 +8,7 @@ use self::uuid::Uuid;
 use std::borrow::Cow;
 use std::borrow::IntoCow;
 use std::ops::Deref;
+use std::error::Error;
 
 pub type SendStr = Cow<'static, str>;
 

--- a/src/def.rs
+++ b/src/def.rs
@@ -193,7 +193,7 @@ impl std::fmt::Display for RCError {
 
 impl std::convert::From<std::io::Error> for RCError {
     fn from(err: std::io::Error) -> RCError {
-        RCError { kind: RCErrorType::IOError, desc: String::from_str(err.description()).into_cow() }   
+        RCError { kind: RCErrorType::IOError, desc: err.description().to_string().into_cow() }   
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //#![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
-#![feature(custom_derive, core, into_cow, convert)]
+#![feature(custom_derive, core, into_cow, convert, collections)]
 
 pub use client::connect;
 pub use def::Consistency;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,10 @@ macro_rules! try_bo(
         match $call {
             Ok(val) => val,
             Err(self::byteorder::Error::UnexpectedEOF) => return Err($crate::def::RCError::new(format!("{} -> {}", $msg, "Unexpected EOF"), $crate::def::RCErrorType::IOError)),
-            Err(self::byteorder::Error::Io(ref err)) => return Err($crate::def::RCError::new(format!("{} -> {}", $msg, err.description()), $crate::def::RCErrorType::IOError))
+            Err(self::byteorder::Error::Io(ref err)) => {
+            	use std::error::Error;
+            	return Err($crate::def::RCError::new(format!("{} -> {}", $msg, err.description()), $crate::def::RCErrorType::IOError))
+            }
         };
     }
 );
@@ -38,7 +41,10 @@ macro_rules! try_io(
     ($call: expr, $msg: expr) => {
         match $call {
             Ok(val) => val,
-            Err(ref err) => return Err(RCError::new(format!("{} -> {}", $msg, err.description()), RCErrorType::IOError))
+            Err(ref err) => {
+            	use std::error::Error;
+            	return Err(RCError::new(format!("{} -> {}", $msg, err.description()), RCErrorType::IOError))
+            }
         };
     }
 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //#![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
-#![feature(custom_derive, core)]
+#![feature(custom_derive, core, into_cow)]
 
 pub use client::connect;
 pub use def::Consistency;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //#![license = "MIT/ASL2"]
 #![crate_type = "rlib"]
 #![crate_type = "dylib"]
-#![feature(custom_derive, core, into_cow)]
+#![feature(custom_derive, core, into_cow, convert)]
 
 pub use client::connect;
 pub use def::Consistency;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -17,9 +17,10 @@ use std::net::Ipv6Addr;
 use std::borrow::IntoCow;
 use std::io::Read;
 use std::io::Write;
-use self::byteorder::{ReadBytesExt, WriteBytesExt, BigEndian, LittleEndian, Error};
+use self::byteorder::{ReadBytesExt, WriteBytesExt, BigEndian, LittleEndian};
 use std::mem::size_of;
 use std::path::Path;
+use std::error::Error;
 
 pub trait CqlReader {
     fn read_exact(&mut self, n: u64) -> RCResult<Vec<u8>>;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -349,7 +349,7 @@ impl<T: std::io::Read> CqlReader for T {
         let rows_count = try_bo!(self.read_u32::<BigEndian>(), "Error reading metadata");
 
         let mut rows:Vec<CqlRow> = vec![];
-        for _ in std::iter::range(0u32, rows_count) {
+        for _ in (0u32..rows_count) {
             let mut row = CqlRow{ cols: vec![] };
             for meta in metadata.row_metadata.iter() {
                 let col = try_rc!(self.read_cql_column_value(meta), "Error reading column value");

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -6,7 +6,6 @@ use std::net::Ipv4Addr;
 use std::net::Ipv6Addr;
 use std::borrow::IntoCow;
 use self::byteorder::{ReadBytesExt, WriteBytesExt, BigEndian, LittleEndian, Error};
-use std::ffi::IntoBytes;
 use std::raw::Slice;
 use std::mem;
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,4 +1,4 @@
-#![feature(macro_rules)]
+#![feature(macro_rules, into_cow)]
 
 #[macro_use]
 extern crate cql;


### PR DESCRIPTION
These minimalistic commits make the compilation possible (`src` and `tests`) using the latest nightly build of Rust.

I'm super new to Rust, and some of the fixes might not be the ideal solution.
