### PR TITLE
Fix running integration tests multiple times

### DIFF
--- a/tests/test_cql/mod.rs
+++ b/tests/test_cql/mod.rs
@@ -17,13 +17,13 @@ fn test() {
     let mut client = try_test!(cql::connect("127.0.0.1", 9042, None), "Error connecting to server at 127.0.0.1:9042");
     println!("Connected with CQL binary version v{}", client.version);
 
-    let mut q = "create keyspace rust with replication = {'class': 'SimpleStrategy', 'replication_factor':1}";
+    let mut q = "create keyspace if not exists rust with replication = {'class': 'SimpleStrategy', 'replication_factor':1}";
     println!("cql::Query: {}", q);
     let mut response = try_test!(client.exec_query(q, cql::Consistency::One), "Error creating keyspace");
     assert_response!(response);
     println!("Result: {:?} \n", response);
 
-    q = "create table rust.test (id text primary key, f32 float, f64 double, i32 int, i64 bigint, b boolean, ip inet)";
+    q = "create table if not exists rust.test (id text primary key, f32 float, f64 double, i32 int, i64 bigint, b boolean, ip inet)";
     println!("cql::Query: {}", q);
     response = try_test!(client.exec_query(q, cql::Consistency::One), "Error creating table rust.test");
     assert_response!(response);
@@ -72,7 +72,7 @@ fn test() {
     assert_response!(response);
     println!("Result: {:?} \n", response);
 
-    q = "create table rust.test2 (id text primary key, l list<int>, m map<int, text>, s set<float>)";
+    q = "create table if not exists rust.test2 (id text primary key, l list<int>, m map<int, text>, s set<float>)";
     println!("cql::Query: {}", q);
     response = try_test!(client.exec_query(q, cql::Consistency::One), "Error creating table test2");
     assert_response!(response);


### PR DESCRIPTION
Use the "IF NOT EXISTS" option in the keyspace and table CQL creation
statements to make it easy to run the integration multiple times.
