### PR TITLE
Fix CQL v3 binary protocol issues

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -32,7 +32,7 @@ impl Client {
         Client {socket: socket, version: version, prepared: BTreeMap::new()}
     }
 
-    fn build_auth<'a>(&self, creds: &'a Vec<CowStr>, stream: i8) -> CqlRequest<'a> {
+    fn build_auth<'a>(&self, creds: &'a Vec<CowStr>, stream: i16) -> CqlRequest<'a> {
         return CqlRequest {
             version: self.version,
             flags: 0x00,

--- a/src/def.rs
+++ b/src/def.rs
@@ -38,6 +38,14 @@ pub enum OpcodeResponse {
     OpcodeUnknown
 }
 
+#[derive(Debug)]
+pub struct CqlFrameHeader {
+    pub version: u8,
+    pub flags: u8,
+    pub stream: i16,
+    pub opcode: u8,
+}
+
 enum_from_primitive! {
 #[derive(Debug, PartialEq)]
 pub enum KindResult {
@@ -313,7 +321,7 @@ pub struct CqlRows {
 pub struct CqlRequest<'a> {
     pub version: u8,
     pub flags: u8,
-    pub stream: i8,
+    pub stream: i16,
     pub opcode: OpcodeRequest,
     pub body: CqlRequestBody<'a>,
 }
@@ -332,7 +340,7 @@ pub enum CqlRequestBody<'a> {
 pub struct CqlResponse {
     pub version: u8,
     pub flags: u8,
-    pub stream: i8,
+    pub stream: i16,
     pub opcode: OpcodeResponse,
     pub body: CqlResponseBody,
 }

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -86,10 +86,14 @@ impl<'a> CqlSerializable<'a> for CqlStringMap {
     }
 }
 
-fn serialize_header<T: std::io::Write>(buf: &mut T, version: &u8, flags: &u8, stream: &i8, opcode: &u8, len: &u32) -> RCResult<()> {
+fn serialize_header<T: std::io::Write>(buf: &mut T, version: &u8, flags: &u8, stream: &i16, opcode: &u8, len: &u32) -> RCResult<()> {
     try_bo!(buf.write_u8(*version), "Error serializing CqlRequest (version)");
     try_bo!(buf.write_u8(*flags), "Error serializing CqlRequest (flags)");
-    try_bo!(buf.write_i8(*stream), "Error serializing CqlRequest (stream)");
+    if *version >= 3 {
+        try_bo!(buf.write_i16::<BigEndian>(*stream), "Error serializing CqlRequest (stream)");
+    } else {
+        try_bo!(buf.write_i8(*stream as i8), "Error serializing CqlRequest (stream)");
+    }
     try_bo!(buf.write_u8(*opcode), "Error serializing CqlRequest (opcode)");
     try_bo!(buf.write_u32::<BigEndian>(*len), "Error serializing CqlRequest (length)");
     Ok(())


### PR DESCRIPTION
Fix v3 issues in frame header and BATCH message serialization. This makes integration tests pass against Cassandra 2.1.11 without having to fallback to v2.
