### PR TITLE
Authentication support

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -424,7 +424,7 @@ impl<T: std::io::Read> CqlReader for T {
         let body = match opcode {
             OpcodeReady => ResponseReady,
             OpcodeAuthenticate => {
-                ResponseAuth(try_rc_noption!(reader.read_cql_str(CqlBytesSize::Cqli16), "Error reading ResponseAuth"))
+                ResponseAuthenticate(try_rc_noption!(reader.read_cql_str(CqlBytesSize::Cqli16), "Error reading ResponseAuthenticate"))
             }
             OpcodeError => {
                 let code = try_bo!(reader.read_u32::<BigEndian>(), "Error reading error code");
@@ -463,6 +463,12 @@ impl<T: std::io::Read> CqlReader for T {
                     }
                     None => return Err(RCError::new("Error reading response body (unknow result kind)", ReadError))
                 }
+            }
+            OpcodeAuthChallenge => {
+                ResponseAuthChallenge(try_rc!(reader.read_cql_bytes(CqlBytesSize::Cqli16), "Error reading ResponseAuthChallenge"))
+            }
+            OpcodeAuthSuccess => {
+                ResponseAuthSuccess(try_rc!(reader.read_cql_bytes(CqlBytesSize::Cqli16), "Error reading ResponseAuthSuccess"))
             }
             _ => {
                 ResultUnknown

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -144,6 +144,12 @@ impl<'a> CqlSerializable<'a> for CqlRequest<'a> {
                 try_io!(buf.write(query_str.as_bytes()), "Error serializing CqlRequest (query)");
                 Ok(())               
             },
+            RequestAuthResponse(ref token) => {
+                let len_str = token.len() as u32;
+                try_bo!(buf.write_u32::<BigEndian>(len_str), "Error serializing CqlRequest (token length)");
+                try_io!(buf.write(token), "Error serializing CqlRequest (token)");
+                Ok(())
+            },
             _ => Ok(())
         }
     }
@@ -169,6 +175,9 @@ impl<'a> CqlSerializable<'a> for CqlRequest<'a> {
                     3 + q_vec_size + 2
                 }
             },
+            RequestAuthResponse(ref token) => {
+                4 + token.len()
+            }
             _ => 0
         }
     }

--- a/tests/test_cql/mod.rs
+++ b/tests/test_cql/mod.rs
@@ -14,7 +14,8 @@ pub fn to_hex_string(bytes: &Vec<u8>) -> String {
 #[test]
 fn test() {
     println!("Connecting ...!");
-    let mut client = try_test!(cql::connect("127.0.0.1", 9042, None), "Error connecting to server at 127.0.0.1:9042");
+    let creds = vec![Cow::Borrowed("cassandra"), Cow::Borrowed("cassandra")];
+    let mut client = try_test!(cql::connect("127.0.0.1", 9042, Some(&creds)), "Error connecting to server at 127.0.0.1:9042");
     println!("Connected with CQL binary version v{}", client.version);
 
     let mut q = "create keyspace if not exists rust with replication = {'class': 'SimpleStrategy', 'replication_factor':1}";


### PR DESCRIPTION
This adds support for authentication for CQL binary protocol version 2
and later. Please note that we only support token generation for
PasswordAuthenticator. The integration tests pass default Cassandra
credentials that are used only if the server requires authentication.
